### PR TITLE
Release/0.1.0 -- Upgrade github action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       id-token: write # This is required for authentication using OIDC
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: "3.3.10"


### PR DESCRIPTION
## Changes:
- Update actions/checkout on github workflow to v4 due to node js v16 which is used by actions/checkout v3 is deprecated