### PR TITLE
fix 🛠️: fix typo on `hour24` variable name

### DIFF
--- a/lib/src/scroll_date_time_picker.dart
+++ b/lib/src/scroll_date_time_picker.dart
@@ -374,7 +374,7 @@ class _ScrollDateTimePickerState extends State<ScrollDateTimePicker> {
           extent = targetDate.weekday - 1;
           break;
         case DateTimeType.hour24:
-          extent = activeDate.hour.toDouble();
+          extent = targetDate.hour.toDouble();
           break;
         case DateTimeType.hour12:
           extent = _helper.convertToHour12(targetDate.hour) - 1;


### PR DESCRIPTION
## Description
fix typo on `hour24` variable name. Changes from activeDate to targetDate.