### PR TITLE
fix 🛠️: update base href on example web

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -14,8 +14,8 @@
     This is a placeholder for base href that will be replaced by the value of
     the `--base-href` argument provided to `flutter build`.
   -->
-  <base href="/">
-
+  <base href="/scroll_datetime_picker/">
+  
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
   <meta name="description" content="A new Flutter project.">


### PR DESCRIPTION
## Issue
Flutter web demo fails to load when deployed to GitHub Pages, resulting in a blank white screen.

## Root Cause
The `base href` configuration in `index.html` was set to '/', which caused asset loading failures when deployed to GitHub Pages under the repository path `/scroll_datetime_picker`.

## Solution
Updated `web/index.html` to use the correct base href path:
```html
- <base href="/">
+ <base href="/scroll_datetime_picker/">
