### PR TITLE
[CI] Separates publish and web deploy workflows

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,0 +1,41 @@
+name: Deploy Example Web
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - master  
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+*"
+  workflow_dispatch: 
+
+jobs:
+  deploy_web_demo:
+    name: "Deploy Example Web to GitHub Pages"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: "3.27.0"
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Build Web Demo
+        run: flutter build web --release --base-href "/scroll_datetime_picker/"
+        working-directory: example
+
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: example/build/web
+          publish_branch: gh-pages
+          force_orphan: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   publish:
-    name: "Publish to pub.dev & Deploy Example Web"
+    name: "Publish to pub.dev"
     permissions:
       id-token: write # This is required for authentication using OIDC
     runs-on: ubuntu-latest
@@ -34,15 +34,3 @@ jobs:
 
       - name: Publish
         run: flutter pub publish --force
-
-      - name: Build Web Demo
-        run: flutter build web --release --base-href "/scroll_datetime_picker/"
-        working-directory: example
-
-      - name: Deploy to gh-pages
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: example/build/web
-          publish_branch: gh-pages
-          force_orphan: true


### PR DESCRIPTION
Splits the publish and web deploy workflows into separate GitHub Actions.

- Creates a new workflow dedicated to deploying the example web application to GitHub Pages.
- Modifies the publish workflow to only handle publishing the package to pub.dev.

This separation improves workflow organization and allows for independent triggering and management of each process.